### PR TITLE
deploy: elevate run-level to circumvent admission

### DIFF
--- a/deploy/namespace.yaml
+++ b/deploy/namespace.yaml
@@ -2,3 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-ssh-bastion
+  labels:
+    openshift.io/run-level: "0"
+


### PR DESCRIPTION
if the openshift-apiserver is not running, we want to still deploy a bastion and not be subject to admission control from aggregated api.