### PR TITLE
Change namespace to ssh-bastion.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ An ssh-bastion pod to make access to openshift clusters easy
 1. Make sure that `oc` is configured to talk to the cluster
 1. Run: `curl https://raw.githubusercontent.com/eparis/ssh-bastion/master/deploy/deploy.sh | bash`
 1. ssh as core to/through the bastion.
-1. The bastion address can be found by running `oc get service -n openshift-ssh-bastion ssh-bastion -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'`
+1. The bastion address can be found by running `oc get service -n ssh-bastion ssh-bastion -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'`
 
 https://raw.githubusercontent.com/eparis/ssh-bastion/master/ssh.sh provides a simple script to automate sshing through to bastion to nodes in the cluster.

--- a/deploy/clusterrolebinding.yaml
+++ b/deploy/clusterrolebinding.yaml
@@ -11,4 +11,4 @@ roleRef:
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
-  name: system:serviceaccount:openshift-ssh-bastion:ssh-bastion
+  name: system:serviceaccount:ssh-bastion:ssh-bastion

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -43,12 +43,12 @@ AcceptEnv XMODIFIERS
 Subsystem	sftp	/usr/libexec/openssh/sftp-server
 ' > ${CONFIGFILE}
 
-    oc create -n openshift-ssh-bastion secret generic ssh-host-keys --from-file="ssh_host_rsa_key=${RSATMP},ssh_host_ecdsa_key=${ECDSATMP},ssh_host_ed25519_key=${ED25519TMP},sshd_config=${CONFIGFILE}"
+    oc create -n ssh-bastion secret generic ssh-host-keys --from-file="ssh_host_rsa_key=${RSATMP},ssh_host_ecdsa_key=${ECDSATMP},ssh_host_ed25519_key=${ED25519TMP},sshd_config=${CONFIGFILE}"
 }
 
 oc apply -f ${BASEDIR}/namespace.yaml
 oc apply -f ${BASEDIR}/service.yaml
-oc get -n openshift-ssh-bastion secret ssh-host-keys &>/dev/null || create_host_keys
+oc get -n ssh-bastion secret ssh-host-keys &>/dev/null || create_host_keys
 oc apply -f ${BASEDIR}/serviceaccount.yaml 
 oc apply -f ${BASEDIR}/role.yaml 
 oc apply -f ${BASEDIR}/rolebinding.yaml 
@@ -60,7 +60,7 @@ retry=120
 while [ $retry -ge 0 ]
 do
     retry=$(($retry-1))
-    bastion_host=$(oc get service -n openshift-ssh-bastion ssh-bastion -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+    bastion_host=$(oc get service -n ssh-bastion ssh-bastion -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
     if [ -z ${bastion_host} ]; then
         sleep 1
     else

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     run: ssh-bastion
   name: ssh-bastion
-  namespace: openshift-ssh-bastion
+  namespace: ssh-bastion
 spec:
   replicas: 1
   selector:

--- a/deploy/namespace.yaml
+++ b/deploy/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: openshift-ssh-bastion
+  name: ssh-bastion
   labels:
     openshift.io/run-level: "0"
 

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: ssh-bastion
-  namespace: openshift-ssh-bastion
+  namespace: ssh-bastion
 rules:
 - apiGroups:
   - security.openshift.io

--- a/deploy/rolebinding.yaml
+++ b/deploy/rolebinding.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     openshift.io/description: Allows ssh-pod to run as root
   name: ssh-bastion
-  namespace: openshift-ssh-bastion
+  namespace: ssh-bastion
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -12,4 +12,4 @@ roleRef:
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
-  name: system:serviceaccount:openshift-ssh-bastion:ssh-bastion
+  name: system:serviceaccount:ssh-bastion:ssh-bastion

--- a/deploy/service.yaml
+++ b/deploy/service.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     run: ssh-bastion
   name: ssh-bastion
-  namespace: openshift-ssh-bastion
+  namespace: ssh-bastion
 spec:
   externalTrafficPolicy: Local
   ports:

--- a/deploy/serviceaccount.yaml
+++ b/deploy/serviceaccount.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: ssh-bastion
-  namespace: openshift-ssh-bastion
+  namespace: ssh-bastion

--- a/ssh.sh
+++ b/ssh.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-ssh -t -o StrictHostKeyChecking=no -o ProxyCommand='ssh -A -o StrictHostKeyChecking=no -o ServerAliveInterval=30 -W %h:%p core@$(oc get service -n openshift-ssh-bastion ssh-bastion -o jsonpath="{.status.loadBalancer.ingress[0].hostname}")' core@$1 "sudo -i"
+ssh -t -o StrictHostKeyChecking=no -o ProxyCommand='ssh -A -o StrictHostKeyChecking=no -o ServerAliveInterval=30 -W %h:%p core@$(oc get service -n ssh-bastion ssh-bastion -o jsonpath="{.status.loadBalancer.ingress[0].hostname}")' core@$1 "sudo -i"


### PR DESCRIPTION
Consider changing the namespace for the ssh-bastion. With the "openshift-" prefix in the namespace, e2e tests will fail if this is deployed in a CI cluster: https://github.com/openshift/origin/blob/master/test/extended/operators/images.go#L81