### PR TITLE
link to MCO instructions for SSH Keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ An ssh-bastion pod to make access to openshift clusters easy
 1. Make sure that `oc` is configured to talk to the cluster
 1. (Optionally configure namespace where the bastion will run: `export SSH_BASTION_NAMESPACE=openshift-ssh-bastion`.
    `openshift-ssh-bastion` is used by default.)
-1. If you SSH key used during deploy of OCP is different from default one you are using, you can
+1. If your SSH key used during deploy of OCP is different from default one you are using, you can
     export this variable SSH_KEY_PATH to change its location. (e.g `export SSH_KEY_PATH=~/.ssh/libra.pem`).
+    You can also directly add or update SSH keys to your OCP deployment see [Update SSH Keys.](https://github.com/openshift/machine-config-operator/blob/master/docs/Update-SSHKeys.md)
 1. Run: `curl https://raw.githubusercontent.com/eparis/ssh-bastion/master/deploy/deploy.sh | bash`
 1. ssh as core to/through the bastion.
 1. The bastion address can be found by running `oc get service -n openshift-ssh-bastion ssh-bastion -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'`


### PR DESCRIPTION
Just linking to the canonical ssh key docs in mco so it's all clearly bundled together. Ran into a problem today where some docs had incorrect ssh info when talking about SSH bastion.  I put in a BZ to correct them, but figured it might help to also link them here. :)