### PR TITLE
Support both IP and hostname ingress endpoints

### DIFF
--- a/ssh.sh
+++ b/ssh.sh
@@ -5,4 +5,5 @@ if [ ! -z "$SSH_KEY_PATH" ]; then
     ssh_key_param="-i $SSH_KEY_PATH"
 fi
 
-ssh $ssh_key_param -t -o StrictHostKeyChecking=no -o ProxyCommand="ssh $ssh_key_param -A -o StrictHostKeyChecking=no -o ServerAliveInterval=30 -W %h:%p core@$(oc get service --all-namespaces -l run=ssh-bastion -o jsonpath='{.items[0].status.loadBalancer.ingress[0].hostname}')" core@$1 "sudo -i"
+ingress_host="$(oc get service --all-namespaces -l run=ssh-bastion -o go-template='{{ with (index (index .items 0).status.loadBalancer.ingress 0) }}{{ or .hostname .ip }}{{end}}')"
+ssh $ssh_key_param -t -o StrictHostKeyChecking=no -o ProxyCommand="ssh $ssh_key_param -A -o StrictHostKeyChecking=no -o ServerAliveInterval=30 -W %h:%p core@${ingress_host}" core@$1 "sudo -i"


### PR DESCRIPTION
The current script only supports hostname-based ingress endpoints.

Azure and GCP use IP ingress endpoints, while AWS uses hostnames. This commit
adds support for both cases.