### PR TITLE
deploy.sh: Fix fail early when oc get fails for hostname or IP

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -76,11 +76,11 @@ retry=120
 while [ $retry -ge 0 ]
 do
     retry=$((retry-1))
-    bastion_host=$(oc get service -n "${SSH_BASTION_NAMESPACE}" ssh-bastion -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+    bastion_host=$(oc get service -n "${SSH_BASTION_NAMESPACE}" ssh-bastion -o jsonpath='{.status.loadBalancer.ingress[0].hostname}' || true)
     if [ -n "${bastion_host}" ]; then
         break
     fi
-    bastion_ip=$(oc get service -n "${SSH_BASTION_NAMESPACE}" ssh-bastion -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+    bastion_ip=$(oc get service -n "${SSH_BASTION_NAMESPACE}" ssh-bastion -o jsonpath='{.status.loadBalancer.ingress[0].ip}' || true)
     if [ -n "${bastion_ip}" ]; then
         break
     fi


### PR DESCRIPTION
If the oc get command fails to reach the api temporarily, the script
exits and does not retry.

Example failure:
```
+ retry=120
+ '[' 120 -ge 0 ']'
+ retry=119
++ oc get service -n test-ssh-bastion ssh-bastion -o 'jsonpath={.status.loadBalancer.ingress[0].hostname}'
+ bastion_host=
+ '[' -n '' ']'
++ oc get service -n test-ssh-bastion ssh-bastion -o 'jsonpath={.status.loadBalancer.ingress[0].ip}'
The connection to the server api.ci-op-dcb0m2si-9de00.origin-ci-int-aws.dev.rhcloud.com:6443 was refused - did you specify the right host or port?
+ bastion_ip=
+ clean_up
+ ARG=1
+ rm -f /tmp/tmp.vUpaLble6z /tmp/tmp.vUpaLble6z.pub
+ rm -f /tmp/tmp.WLzMCInfk5 /tmp/tmp.WLzMCInfk5.pub
+ rm -f /tmp/tmp.UkdBCO7lwZ /tmp/tmp.UkdBCO7lwZ.pub
+ rm -f /tmp/tmp.NM7A4SKNa5
+ exit 1
```
CI Failure Search:
https://search.apps.build01.ci.devcluster.openshift.com/?search=did+you+specify+the+right+host+or+port&maxAge=48h&context=1&type=build-log&name=rhel7&maxMatches=5&maxBytes=20971520&groupBy=job