### PR TITLE
fix IP retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ An ssh-bastion pod to make access to openshift clusters easy
     > * Directly add or update the SSH keys in your OCP deployment see [Update SSH Keys][update-ssh-keys].
 1. The bastion address can be found by running:
     ```
-    oc get service -n openshift-ssh-bastion ssh-bastion -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'
+    oc get service --all-namespaces -l run=ssh-bastion -o go-template='{{ with (index (index .items 0).status.loadBalancer.ingress 0) }}{{ or .hostname .ip }}{{end}}'
     ```
 
 [ssh-script]: https://raw.githubusercontent.com/eparis/ssh-bastion/master/ssh.sh

--- a/scp.sh
+++ b/scp.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
-scp -o ProxyCommand='ssh -A -o StrictHostKeyChecking=no -o ServerAliveInterval=30 -W %h:%p core@$(oc get service --all-namespaces -l run=ssh-bastion -o jsonpath="{.items[0].status.loadBalancer.ingress[0].hostname}")' core@$1:$2 $3
+ingress_host="$(oc get service --all-namespaces -l run=ssh-bastion -o go-template='{{ with (index (index .items 0).status.loadBalancer.ingress 0) }}{{ or .hostname .ip }}{{end}}')"
+
+scp -o ProxyCommand="ssh -A -o StrictHostKeyChecking=no -o ServerAliveInterval=30 -W %h:%p core@${ingress_host}" core@$1:$2 $3


### PR DESCRIPTION
```bash
$ oc get clusterversion 
NAME      VERSION   AVAILABLE   PROGRESSING   SINCE   STATUS
version   4.5.2     True        False         20m     Cluster version is 4.5.2
```

The existing script doesn't work,

```bash
$ oc get service --all-namespaces -l run=ssh-bastion -o jsonpath="{.items[0].status.loadBalancer.ingress[0].hostname}"
[harshal@localhost cadvisor]$ 
```

With the fix,
```bash
 oc get service --all-namespaces -l run=ssh-bastion -o jsonpath="{.items[0].status.loadBalancer.ingress[0].ip}"
xx.xx.4.105[harshal@localhost cadvisor]$
```
```bash