### PR TITLE
add pod-security labels

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -59,6 +59,10 @@ metadata:
   name: ${SSH_BASTION_NAMESPACE}
   labels:
     openshift.io/run-level: "0"
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
+    security.openshift.io/scc.podSecurityLabelSync=false
 EOF
 oc apply -f "${BASEDIR}/clusterrole.yaml"
 


### PR DESCRIPTION
Tracking down failures in CI due to pod security changes.  Working through [TRT-540](https://issues.redhat.com/browse/TRT-540) and a number of these have errors like

`Sep 08 14:35:01.000 W ns/test-ssh-bastion replicaset/ssh-bastion-86999b68b8 reason/FailedCreate (combined from similar events): Error creating: pods "ssh-bastion-86999b68b8-jp6k8" is forbidden: violates PodSecurity "restricted:v1.24": privileged (container "ssh-bastion" must not set securityContext.privileged=true)`

See the following in multiple places
`    # if this is run from a flow that does not have the ssh-bastion step, deploy the bastion
    if ! oc get -n "${SSH_BASTION_NAMESPACE}" ssh-bastion; then
        curl https://raw.githubusercontent.com/eparis/ssh-bastion/master/deploy/deploy.sh | bash -x
    fi`
    
Update should add the required labels to correct the issue.    